### PR TITLE
URI components such as redirect_uri should be encoded

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ function urlBuilderAuthorize(
     // Finally, build the URL
     .forEach(([key, value], index) => {
       url += index === 0 ? `?` : "&";
-      url += `${key}=${value}`;
+      url += `${key}=${encodeURIComponent(value)}`;
     });
 
   return url;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -17,8 +17,7 @@ test('oauthAuthorizationUrl({clientId: "1234567890abcdef1234"})', () => {
     redirectUrl: null,
     scopes: [],
     state: "4feornbt361",
-    url:
-      "https://github.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&state=4feornbt361",
+    url: "https://github.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&state=4feornbt361",
   });
 });
 
@@ -35,8 +34,7 @@ test('oauthAuthorizationUrl({clientId: "1234567890abcdef1234", clientType: "oaut
     redirectUrl: null,
     scopes: [],
     state: "4feornbt361",
-    url:
-      "https://github.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&state=4feornbt361",
+    url: "https://github.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&state=4feornbt361",
   });
 });
 
@@ -53,8 +51,7 @@ test('oauthAuthorizationUrl({clientId: "lv1.1234567890abcdef", clientType: "gith
     login: null,
     redirectUrl: null,
     state: "4feornbt361",
-    url:
-      "https://github.com/login/oauth/authorize?allow_signup=true&client_id=lv1.1234567890abcdef&state=4feornbt361",
+    url: "https://github.com/login/oauth/authorize?allow_signup=true&client_id=lv1.1234567890abcdef&state=4feornbt361",
   });
 });
 
@@ -71,8 +68,7 @@ test('oauthAuthorizationUrl({clientId: "4321fedcba0987654321"})', () => {
     redirectUrl: null,
     scopes: [],
     state: "4feornbt361",
-    url:
-      "https://github.com/login/oauth/authorize?allow_signup=true&client_id=4321fedcba0987654321&state=4feornbt361",
+    url: "https://github.com/login/oauth/authorize?allow_signup=true&client_id=4321fedcba0987654321&state=4feornbt361",
   });
 });
 
@@ -80,18 +76,17 @@ test("redirectUrl option", () => {
   expect(
     oauthAuthorizationUrl({
       clientId: "1234567890abcdef1234",
-      redirectUrl: "https://example.com",
+      redirectUrl: "https://example.com?q=octocat&sort=date",
     })
   ).toEqual({
     allowSignup: true,
     clientId: "1234567890abcdef1234",
     clientType: "oauth-app",
     login: null,
-    redirectUrl: "https://example.com",
+    redirectUrl: "https://example.com?q=octocat&sort=date",
     scopes: [],
     state: "4feornbt361",
-    url:
-      "https://github.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&redirect_uri=https://example.com&state=4feornbt361",
+    url: "https://github.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&redirect_uri=https%3A%2F%2Fexample.com%3Fq%3Doctocat%26sort%3Ddate&state=4feornbt361",
   });
 });
 
@@ -109,8 +104,7 @@ test("login option", () => {
     redirectUrl: null,
     scopes: [],
     state: "4feornbt361",
-    url:
-      "https://github.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&login=octocat&state=4feornbt361",
+    url: "https://github.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&login=octocat&state=4feornbt361",
   });
 });
 
@@ -129,8 +123,7 @@ test("scopes = []", () => {
     redirectUrl: null,
     scopes: [],
     state: "4feornbt361",
-    url:
-      "https://github.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&login=octocat&state=4feornbt361",
+    url: "https://github.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&login=octocat&state=4feornbt361",
   });
 });
 
@@ -149,8 +142,7 @@ test('scopes = ""', () => {
     redirectUrl: null,
     scopes: [],
     state: "4feornbt361",
-    url:
-      "https://github.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&login=octocat&state=4feornbt361",
+    url: "https://github.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&login=octocat&state=4feornbt361",
   });
 });
 
@@ -169,8 +161,7 @@ test('scopes = "user,public_repo, gist notifications"', () => {
     redirectUrl: null,
     scopes: ["user", "public_repo", "gist", "notifications"],
     state: "4feornbt361",
-    url:
-      "https://github.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&login=octocat&scope=user,public_repo,gist,notifications&state=4feornbt361",
+    url: "https://github.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&login=octocat&scope=user%2Cpublic_repo%2Cgist%2Cnotifications&state=4feornbt361",
   });
 });
 
@@ -190,8 +181,7 @@ test("allowSignup = false", () => {
     redirectUrl: null,
     scopes: ["user", "public_repo", "gist", "notifications"],
     state: "4feornbt361",
-    url:
-      "https://github.com/login/oauth/authorize?allow_signup=false&client_id=1234567890abcdef1234&login=octocat&scope=user,public_repo,gist,notifications&state=4feornbt361",
+    url: "https://github.com/login/oauth/authorize?allow_signup=false&client_id=1234567890abcdef1234&login=octocat&scope=user%2Cpublic_repo%2Cgist%2Cnotifications&state=4feornbt361",
   });
 });
 
@@ -210,8 +200,7 @@ test("state = Sjn2oMwNFZPiVm6Mtjn2o9b3xxZ4sVEI", () => {
     redirectUrl: null,
     scopes: [],
     state: "Sjn2oMwNFZPiVm6Mtjn2o9b3xxZ4sVEI",
-    url:
-      "https://github.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&login=octocat&state=Sjn2oMwNFZPiVm6Mtjn2o9b3xxZ4sVEI",
+    url: "https://github.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&login=octocat&state=Sjn2oMwNFZPiVm6Mtjn2o9b3xxZ4sVEI",
   });
 });
 
@@ -229,7 +218,6 @@ test('oauthAuthorizationUrl({clientId: "1234567890abcdef1234", baseUrl: "https:/
     redirectUrl: null,
     scopes: [],
     state: "4feornbt361",
-    url:
-      "https://github.my-enterprise.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&state=4feornbt361",
+    url: "https://github.my-enterprise.com/login/oauth/authorize?allow_signup=true&client_id=1234567890abcdef1234&state=4feornbt361",
   });
 });


### PR DESCRIPTION
Redirect uri such as `https://acme.com?q=octocat&sort=date` should be encoded. 

Without `encodeURIComponent`, `oauth-authorization-url.js` generates `https://github.com/login/oauth/authorize?client_id=123&redirect_uri=https://acme.com?q=octocat&sort=date&state=4feornbt361`, which will not be interpreted as expected.