### PR TITLE
ci: stop testing against NodeJS v10, v12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,9 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 10
-          - 12
           - 14
           - 16
+          - 18
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
       - name: "Use Node.js ${{ matrix.node_version }}"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,10 @@
         "@pika/plugin-ts-standard-pkg"
       ],
       [
-        "@pika/plugin-build-node"
+        "@pika/plugin-build-node",
+        {
+          "minNodeVersion": "14"
+        }
       ],
       [
         "@pika/plugin-build-web"
@@ -75,5 +78,8 @@
     "extends": [
       "github>octokit/.github"
     ]
+  },
+  "engines": {
+    "node": ">= 14"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Drop support for NodeJS v10, v12