### PR TITLE
Remove unused pika package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "esbuild": "^0.17.19",
         "glob": "^10.2.6",
         "jest": "^29.0.0",
-        "pika-plugin-unpkg-field": "^1.0.1",
         "prettier": "2.8.8",
         "ts-jest": "^29.0.0",
         "typescript": "^5.0.0"
@@ -5104,12 +5103,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pika-plugin-unpkg-field": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pika-plugin-unpkg-field/-/pika-plugin-unpkg-field-1.1.0.tgz",
-      "integrity": "sha512-NUCm4syeu/BOitSoKI7/NXB/K8e1n4IU7PlXYN7NkRKuY0xbsPTqsJ9/3iQwGUMmzltLzov0pQtlrK1FjxJVgw==",
-      "dev": true
-    },
     "node_modules/pirates": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
@@ -9737,12 +9730,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
-    },
-    "pika-plugin-unpkg-field": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pika-plugin-unpkg-field/-/pika-plugin-unpkg-field-1.1.0.tgz",
-      "integrity": "sha512-NUCm4syeu/BOitSoKI7/NXB/K8e1n4IU7PlXYN7NkRKuY0xbsPTqsJ9/3iQwGUMmzltLzov0pQtlrK1FjxJVgw==",
       "dev": true
     },
     "pirates": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "esbuild": "^0.17.19",
     "glob": "^10.2.6",
     "jest": "^29.0.0",
-    "pika-plugin-unpkg-field": "^1.0.1",
     "prettier": "2.8.8",
     "ts-jest": "^29.0.0",
     "typescript": "^5.0.0"

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -79,6 +79,7 @@ async function main() {
         types: "dist-types/index.d.ts",
         module: "dist-src/index.js",
         sideEffects: false,
+        unpkg: "dist-web/index.js"
       },
       null,
       2


### PR DESCRIPTION
I'm going around and removing pika from our dependencies in favor of esbuild and tsc. This module has already been updated to build with tsc, but I forgot to remove an unused pika package from the package.json. 