### PR TITLE
docs: replace references to Skypack CDN with esm.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ See [GitHub’s Developer Guide for the OAuth App web application flow](https://
       </th>
       <td width=100%>
 
-Load `@octokit/oauth-authorization-url` directly from [cdn.skypack.dev](https://cdn.skypack.dev)
+Load `@octokit/oauth-authorization-url` directly from [esm.sh](https://esm.sh)
 
 ```html
 <script type="module">
-  import { oauthAuthorizationUrl } from "https://cdn.skypack.dev/@octokit/oauth-authorization-url";
+  import { oauthAuthorizationUrl } from "https://esm.sh/@octokit/oauth-authorization-url";
 </script>
 ```
 


### PR DESCRIPTION
The Skypack CDN is no longer maintained, so we should remove references to it.