### PR TITLE
fix: add `main` entry point

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -52,6 +52,8 @@ async function main() {
       {
         ...pkg,
         files: ["dist-*/**"],
+        main: "./dist-src/index.js",
+        types: "./dist-types/index.d.ts",
         exports: {
           ".": {
             types: "./dist-types/index.d.ts",


### PR DESCRIPTION
Some tools don't play well with only having the `exports` field present.

See octokit/core.js#662