### PR TITLE
fix(pkg): add a `default` fallback export

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ const { oauthAuthorizationUrl } = require("@octokit/oauth-authorization-url");
 </tbody>
 </table>
 
+> [!IMPORTANT]
+> As we use [conditional exports](https://nodejs.org/api/packages.html#conditional-exports), you will need to adapt your `tsconfig.json` by setting `"moduleResolution": "node16", "module": "node16"`.
+>
+> See the TypeScript docs on [package.json "exports"](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports).<br>
+> See this [helpful guide on transitioning to ESM](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) from [@sindresorhus](https://github.com/sindresorhus)
+
 ### For OAuth Apps
 
 ```js

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -52,12 +52,13 @@ async function main() {
       {
         ...pkg,
         files: ["dist-*/**"],
-        main: "./dist-src/index.js",
         types: "./dist-types/index.d.ts",
         exports: {
           ".": {
             types: "./dist-types/index.d.ts",
             import: "./dist-src/index.js",
+            // Tooling currently are having issues with the "exports" field when there is no "default", ex: TypeScript, eslint
+            default: "./dist-src/index.js",
           },
         },
         sideEffects: false,


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

See octokit/core.js#667 
See octokit/core.js#665
Partly reverts #355

---

### Before the change?

<!-- Please describe the current behavior that you are modifying. -->

- Some consumers of this package could not resolve it properly (ex: `jest`, `ts-node`, `tsx`)
- CJS consumers would be getting errors even though the package is ESM

### After the change?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Clients should be able to import the module without any errors with the fallback
- CJS consumers will generate a better error with the new fallback


### Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

---
